### PR TITLE
LTI-234 Maven release fails due to spotless not being able to find or…

### DIFF
--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -39,7 +39,7 @@ jobs:
           git config user.name "LTS Bot"
           git config user.email "lts-devs@virginia.edu"
       - name: Release
-        run: mvn --batch-mode clean release:prepare release:perform -DdryRun=${{inputs.dryRun}} -DreleaseVersion=${{inputs.releaseVersion}} -DdevelopmentVersion=${{inputs.developmentVersion}}
+        run: mvn --batch-mode clean release:prepare release:perform -DscmShallowClone=false -DdryRun=${{inputs.dryRun}} -DreleaseVersion=${{inputs.releaseVersion}} -DdevelopmentVersion=${{inputs.developmentVersion}}
         env:
           GITHUB_TOKEN: ${{secrets.DEPLOY_GITHUB_TOKEN}}
 


### PR DESCRIPTION
…igin/main since the release plugin does a shallow checkout when it tries to verify changes