### PR TITLE
LTI-234 We still need the deploy action in order to create a new task…

### DIFF
--- a/.github/workflows/aws-deploy-prod.yaml
+++ b/.github/workflows/aws-deploy-prod.yaml
@@ -84,3 +84,7 @@ jobs:
           task-definition: task-definition.json
           container-name: ${{ inputs.ecs_container_name }}
           image: ${{ steps.push-image.outputs.image }}
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}


### PR DESCRIPTION
… definition, the prod version doesn't have the service/cluster args set as without them the service won't auto-deploy